### PR TITLE
Disable wasm-opt to allow ui to compile on the Arm64 Raspberry pi target

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -42,3 +42,7 @@ wasm-bindgen-test = "0.3.34"
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+


### PR DESCRIPTION
fixes #34 